### PR TITLE
Further debug image modal not opening.

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -264,16 +264,24 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // --- Image Modal Logic ---
     function showImageModal(imageUrl) {
+        console.log("--- Attempting to show image modal ---"); // Specific log
+        console.log("Searching for ID: 'imageModalOverlay'"); // Specific log
         const imageModalOverlay = document.getElementById('imageModalOverlay');
+        console.log("Element found for 'imageModalOverlay':", imageModalOverlay); // Specific log
+
+        console.log("Searching for ID: 'fullImageDisplay'"); // Specific log
         const fullImageDisplay = document.getElementById('fullImageDisplay');
-        console.log("showImageModal called with URL:", imageUrl);
+        console.log("Element found for 'fullImageDisplay':", fullImageDisplay); // Specific log
+
+        // The original console.log for the URL can remain if desired, or be removed if too verbose
+        // console.log("showImageModal called with URL:", imageUrl);
 
         if (!imageModalOverlay) {
-            console.error("imageModalOverlay element not found IN showImageModal!");
+            console.error("CRITICAL: imageModalOverlay element NOT FOUND at the moment of call!");
             return;
         }
         if (!fullImageDisplay) {
-            console.error("fullImageDisplay element not found IN showImageModal!");
+            console.error("CRITICAL: fullImageDisplay element NOT FOUND at the moment of call!");
             return;
         }
 


### PR DESCRIPTION
- Modifies showImageModal in static/js/main.js to include more specific console.log statements before and after getElementById for 'imageModalOverlay' and 'fullImageDisplay'. This is to help diagnose why these elements might not be found at runtime for the user.
- This commit is primarily for diagnostics based on user feedback.