### PR TITLE
Enable editing of closed trade status and details.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Esta aplicación web permite registrar operaciones de opciones, las clasifica po
     - **Notificaciones Pop-up Interactivas:** Confirmaciones de guardado y errores con animaciones (incluyendo "destellos" para éxito).
     - **Gestión de Operaciones:**
         - **Creación:** Entrada detallada de operaciones multi-leg.
-        - **Edición:** Permite modificar todos los aspectos de una operación guardada (incluyendo legs e imágenes).
-        - **Cierre de Operaciones:** Permite marcar operaciones como "Cerrada", registrando el P/L real, fecha de cierre y notas de cierre. La interfaz se actualiza para reflejar este estado.
+        - **Edición Avanzada:** Permite modificar todos los aspectos de una operación guardada, incluyendo ticker, notas, legs (con recálculo de estrategia/riesgo), añadir imágenes, cambiar el estado de la operación (Abierta/Cerrada) y editar los detalles de cierre (P/L real, fecha, notas de cierre).
+        - **Cierre Rápido de Operaciones:** Un modal dedicado permite marcar rápidamente operaciones como "Cerrada", registrando el P/L real, fecha de cierre y notas de cierre.
         - **Eliminación:** Permite eliminar registros de estrategias con confirmación (incluyendo la eliminación de imágenes asociadas del servidor).
     - **Visualización de Imágenes Mejorada:** Las imágenes adjuntas se muestran en un modal (pop-up) dentro de la página en lugar de abrir en una nueva pestaña.
     - **Visualización Agrupada:** Muestra las estrategias guardadas, agrupadas por mes de vencimiento, con animaciones de carga.

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -500,6 +500,55 @@ button[type="submit"]:hover, #addLegBtn:hover {
     background-color: #1e7e34;
 }
 
+/* Styles for Closing Details Section in Main Form */
+#closingDetailsSection {
+    margin-top: 25px;
+    margin-bottom: 20px;
+    border: 1px solid #4f545c; /* Slightly lighter border than main form inputs */
+    padding: 20px;
+    border-radius: 8px;
+    background-color: #333336; /* Same as leg-row for differentiation */
+}
+
+#closingDetailsSection legend {
+    color: #00aeff; /* Accent color */
+    font-weight: bold;
+    font-size: 1.1em;
+    padding: 0 10px;
+    margin-left: 5px; /* Align with padding of fieldset */
+}
+
+#closingDetailsSection div { /* Wrapper for label + input within fieldset */
+    margin-bottom: 15px;
+}
+
+#closingDetailsSection label {
+    color: #b8c2cc; /* Slightly lighter labels within this section */
+    margin-bottom: 6px;
+}
+
+#closingDetailsSection input[type="number"],
+#closingDetailsSection input[type="date"],
+#closingDetailsSection textarea,
+#closingDetailsSection select {
+    /* Inherits most styles from general input styling */
+    /* Specific adjustments if needed: */
+    background-color: #3c3f41; /* Slightly different bg for inputs in this section */
+    border-color: #525860;
+    font-size: 0.95em; /* Slightly smaller font if desired */
+    padding: 10px 12px;
+}
+
+#closingDetailsSection select {
+    /* Ensure select arrow matches dark theme if browser default is problematic */
+    /* This is often tricky to style universally without custom select replacements */
+    appearance: none; /* Basic reset, may need more for full custom arrow */
+    background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23c0c0c0%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.6-3.6%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.4-13z%22%2F%3E%3C%2Fsvg%3E');
+    background-repeat: no-repeat;
+    background-position: right 12px center;
+    background-size: 10px 10px;
+    padding-right: 30px; /* Make space for arrow */
+}
 .strategy-details {
     margin-top: 15px;
     padding-top: 15px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,6 +23,7 @@
                 <h1>Bitácora de Estrategias de Opciones</h1>
                 <form id="strategyForm">
                     <input type="hidden" id="editingTradeIdField" name="tradeId">
+
                     <h2>Información General de la Operación</h2>
                     <div>
                         <label for="ticker">Activo Subyacente (Ticker):</label>
@@ -36,6 +37,29 @@
                         <label for="marketVision">Visión del Mercado / Justificación:</label>
                         <textarea id="marketVision" name="marketVision" rows="4"></textarea>
                     </div>
+
+                    <fieldset id="closingDetailsSection" style="display: none; margin-top: 20px; border: 1px solid #444; padding: 15px; border-radius: 8px;">
+                        <legend style="color: #00aeff; padding: 0 10px; font-weight: bold;">Detalles de Cierre (si aplica)</legend>
+                        <div>
+                            <label for="trade_status">Estado de la Operación:</label>
+                            <select id="trade_status" name="status" style="width: 100%; padding: 10px; background-color: #36363a; color: #e0e0e0; border: 1px solid #444; border-radius: 6px;">
+                                <option value="Abierta">Abierta</option>
+                                <option value="Cerrada">Cerrada</option>
+                            </select>
+                        </div>
+                        <div id="actualPlDiv" style="display: none;"> <!-- Se mostrará si status es 'Cerrada' -->
+                            <label for="form_actual_pl">P/L Real:</label>
+                            <input type="number" id="form_actual_pl" name="actual_pl" step="any">
+                        </div>
+                        <div id="closingDateDiv" style="display: none;"> <!-- Se mostrará si status es 'Cerrada' -->
+                            <label for="form_closing_date">Fecha de Cierre:</label>
+                            <input type="date" id="form_closing_date" name="closing_date_str">
+                        </div>
+                        <div id="closingNotesDiv" style="display: none;"> <!-- Se mostrará si status es 'Cerrada' -->
+                            <label for="form_closing_notes">Notas de Cierre:</label>
+                            <textarea id="form_closing_notes" name="closing_notes" rows="3"></textarea>
+                        </div>
+                    </fieldset>
 
                     <h2>Constructor de Legs</h2>
                     <div id="legsContainer">


### PR DESCRIPTION
- Modifies the backend update route (PUT /api/update_strategy/<trade_id>) to allow changes to a trade's 'status' (Open/Closed), 'actual_pl', 'closing_date', and 'closing_notes'.
- If status is changed to 'Open', closing details are cleared.
- If status is 'Closed', closing details are updated/set (actual P/L and closing date become mandatory if closing via edit form).
- Frontend form for editing trades now includes a section for these closing details, which is shown when editing any trade. The section's fields are populated if the trade is already closed.
- Users can now reopen a closed trade or modify its closing P/L, date, and notes.
- The 'Edit' button is now always visible on strategy cards, regardless of status.
- README updated to reflect these advanced editing capabilities.