### PR TITLE
Fix: Remove visible code comment from strategy card UI.

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -519,7 +519,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     `}
                     <div class="card-actions">
                         <button class="view-details-btn">Ver Detalles</button>
-                        <button class="edit-strategy-btn" data-trade-id="${strategy.id}">Editar</button> {/* Editar siempre visible */}
+                        <button class="edit-strategy-btn" data-trade-id="${strategy.id}">Editar</button>
                         ${strategy.status !== 'Cerrada' ? `<button class="close-trade-btn" data-trade-id="${strategy.id}">Registrar Cierre</button>` : ''}
                         <button class="delete-strategy-btn" data-trade-id="${strategy.id}">Eliminar</button>
                     </div>


### PR DESCRIPTION
- Deletes an unintentionally rendered JavaScript code comment (`{/* Editar siempre visible */}`) that was appearing next to the 'Edit' button on strategy cards.
- The comment was part of the HTML string template in the `renderStrategies` function in `static/js/main.js`.