### PR TITLE
Refactor: Improve error handling and logging in /api/get_strategies.

### DIFF
--- a/app.py
+++ b/app.py
@@ -157,10 +157,20 @@ def index():
 def get_strategies():
     try:
         trades = Trade.query.order_by(Trade.entry_date.desc()).all()
-        return jsonify(success=True, strategies=[trade.to_dict() for trade in trades])
-    except Exception as e:
-        print(f"Error fetching strategies: {e}")
-        return jsonify(success=False, message=f"Error fetching strategies: {str(e)}"), 500
+        strategies_data = []
+        for trade in trades:
+            try:
+                strategies_data.append(trade.to_dict())
+            except Exception as e_serialize:
+                print(f"Error serializing trade ID {trade.id}: {e_serialize}")
+                # Decide si continuar o fallar todo. Por ahora, omitimos el trade problemático.
+                # Alternativamente, podrías añadir un placeholder o un mensaje de error para ese trade.
+        return jsonify(success=True, strategies=strategies_data)
+    except Exception as e_query:
+        print(f"CRITICAL Error fetching or processing strategies: {e_query}")
+        import traceback
+        traceback.print_exc() # Print full traceback to Flask console
+        return jsonify(success=False, message=f"Error crítico al obtener estrategias: {str(e_query)}"), 500
 
 @app.route('/api/hello') # Keep a distinct API endpoint if needed
 def hello_api():


### PR DESCRIPTION
- Modifies the /api/get_strategies endpoint in app.py to include more robust error handling.
- Adds a try-except block around the database query (Trade.query.all()). If this fails, a critical error and full traceback are printed to the Flask console.
- Adds a try-except block for the serialization (trade.to_dict()) of each individual trade. If a specific trade fails to serialize, an error is printed to the Flask console (including the trade ID), and that trade is omitted from the results, allowing other valid trades to still be returned.
- This change is intended to prevent the entire API call from failing due to a single problematic record and to provide more detailed error messages in the Flask server console for diagnosing 'Network Error' issues on the frontend.